### PR TITLE
cpython compatibility fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,7 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
                  %/tmpnam.c %/tmpfile.c %/tempnam.c \
                  %/popen.c %/pclose.c \
                  %/remove.c \
+                 %/memfd_create.c \
                  %/gets.c, \
                  $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/stdio/*.c)) \
     $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/string/*.c) \

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -6372,7 +6372,7 @@
 #define __wasi_libc_find_relpath_h 
 #define __wasi_libc_h 
 #define __wasi_libc_nocwd_h 
-#define __wasi_polyfill_h
+#define __wasi_polyfill_h 
 #define __wasilibc___errno_h 
 #define __wasilibc___errno_values_h 
 #define __wasilibc___fd_set_h 
@@ -6449,7 +6449,7 @@
 #define __wasilibc___typedef_time_t_h 
 #define __wasilibc___typedef_uid_t_h 
 #define __wasix__ 1
-#define __wasix_api_h
+#define __wasix_api_h 
 #define __wasm 1
 #define __wasm32 1
 #define __wasm32__ 1

--- a/libc-bottom-half/cloudlibc/src/libc/sys/socket/getsockname.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/socket/getsockname.c
@@ -9,7 +9,7 @@
 
 int getsockname(int socket, struct sockaddr *restrict addr, socklen_t *restrict addrlen) {
   __wasi_addr_port_t local_addr;
-  __wasi_errno_t error = __wasi_sock_addr_peer(socket, &local_addr);
+  __wasi_errno_t error = __wasi_sock_addr_local(socket, &local_addr);
   if (error != 0) {
     errno = error;
     return -1;

--- a/libc-top-half/musl/include/sys/mman.h
+++ b/libc-top-half/musl/include/sys/mman.h
@@ -129,7 +129,7 @@ int munlock (const void *, size_t);
 int mlockall (int);
 int munlockall (void);
 
-#ifdef _GNU_SOURCE
+#if defined(_GNU_SOURCE) && defined(__wasi_unmodified_upstream)
 void *mremap (void *, size_t, size_t, int, ...);
 int remap_file_pages (void *, size_t, int, size_t, int);
 int memfd_create (const char *, unsigned);


### PR DESCRIPTION
- mman: disable `memfd_open`
  - necessary to get `sem_open` working for cpython
- getsockname: properly use `__wasi_sock_addr_local`
  - necessary to get `python.wasm -m http.server <port>` working
