### PR TITLE
signal.h: fix usage on C++

### DIFF
--- a/libc-top-half/musl/arch/wasm32/bits/signal.h
+++ b/libc-top-half/musl/arch/wasm32/bits/signal.h
@@ -10,7 +10,7 @@ struct sigaltstack {
 
 typedef struct sigaltstack stack_t;
 
-int sigaltstack(const stack_t *restrict ss, stack_t *restrict old);
+int sigaltstack(const stack_t *__restrict ss, stack_t *__restrict old);
 
 #define MINSIGSTKSZ 2048
 #define SIGSTKSZ 8192


### PR DESCRIPTION
Every other musl header uses `__restrict`, which is supported in C++, whereas `restrict` is not a valid C++ keyword (fun fact: it's the only C keyword not supported in C++)