### PR TITLE
Add clang builtin symbols to libc.a

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -515,6 +515,13 @@ wasix-headers:
 	cargo run --manifest-path tools/wasix-headers/Cargo.toml generate-libc
 
 post-finish: finish
+ifeq ($(TARGET_TRIPLE), wasm32-wasi)
+	cd $(SYSROOT)/lib/$(TARGET_TRIPLE) && \
+	mv libc.a libc-old.a && \
+	$(AR) -M < ../../../tools/append-builtins/$(TARGET_TRIPLE).mri && \
+	rm libc-old.a
+endif
+
 	rm -f sysroot/lib/wasm32-wasi/libc-printscan-log-double.a
 	rsync -rtvu --delete ./sysroot/ ./sysroot32/
 

--- a/build32.sh
+++ b/build32.sh
@@ -9,6 +9,8 @@ git reset --hard
 git pull origin main || true
 cd ../../..
 
+make clean
+
 # Build the extensions
 cargo run --manifest-path tools/wasix-headers/Cargo.toml generate-libc
 cp -f libc-bottom-half/headers/public/wasi/api.h libc-bottom-half/headers/public/wasi/api_wasix.h

--- a/tools/append-builtins/wasm32-wasi.mri
+++ b/tools/append-builtins/wasm32-wasi.mri
@@ -1,0 +1,5 @@
+create libc.a
+addlib libc-old.a
+addlib ../../../libclang_rt.builtins-wasm32.a
+save
+end


### PR DESCRIPTION
This PR fixes #13. However, I'm not sure if this change causes side-effects or not.