### PR TITLE
Fix sockets

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/sys/socket/getsockname.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/socket/getsockname.c
@@ -9,7 +9,7 @@
 
 int getsockname(int socket, struct sockaddr *restrict addr, socklen_t *restrict addrlen) {
   __wasi_addr_port_t local_addr;
-  __wasi_errno_t error = __wasi_sock_addr_peer(socket, &local_addr);
+  __wasi_errno_t error = __wasi_sock_addr_local(socket, &local_addr);
   if (error == ENOTSOCK) {
     // in that case, return a AF_LOCAL type constant
     *addrlen = sizeof(addr->sa_family);

--- a/libc-bottom-half/cloudlibc/src/libc/sys/socket/setsockopt.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/socket/setsockopt.c
@@ -67,7 +67,7 @@ int setsockopt(int socket, int level, int option_name, const void *restrict opti
 	  __wasi_option_timestamp_t tm;
 	  if (option_len >= sizeof(struct timeval)) {
 		struct timeval *tv = (struct timeval *)option_value;
-		tm.tag = tv->tv_sec > 0 && tv->tv_usec > 0 ? __WASI_OPTION_SOME : __WASI_OPTION_NONE;
+		tm.tag = tv->tv_sec > 0 || tv->tv_usec > 0 ? __WASI_OPTION_SOME : __WASI_OPTION_NONE;
 		tm.u.some = (tv->tv_sec * 1000000000ULL) + (tv->tv_usec * 1000ULL);
 	  } else {
 		errno = EINVAL;


### PR DESCRIPTION
A couple of small socket-related fixes:

* `getsockname` was calling `__wasi_sock_addr_peer` instead of `__wasi_sock_addr_local`.
* `timeval` serialization was ignoring values without non-zero values for *both* `tv_sec` and `tv_usec`.