### PR TITLE
Mention unofficial sysroot build in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ progress.
 
 ## Usage
 
-The easiest way to get started with this is to use [wasi-sdk], which includes a
-build of WASI Libc in its sysroot.
+There is no official SDK like `wasi-sdk` for `wasix-libc`. However, there is an unofficial C/C++ sysroot build available at [wasix-sysroot](https://github.com/SanderVocke/wasix-sysroot).
 
 ## Building from source
 


### PR DESCRIPTION
I noticed that it is quite a hurdle to get going with `wasix-libc`, especially if you also want `libc++` for C++ support. It requires building everything from scratch and there are also some small obstacles on the way.

I created a repo to build and release a complete `sysroot` with `wasix-libc` and `libc++`. Please consider mentioning it in your README (see proposal) so people can easily find it.