### PR TITLE
clock_nanosleep: Use timespec_to_timestamp_exact instead

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/time/clock_nanosleep.c
+++ b/libc-bottom-half/cloudlibc/src/libc/time/clock_nanosleep.c
@@ -24,7 +24,7 @@ int clock_nanosleep(clockid_t clock_id, int flags, const struct timespec *rqtp,
       .u.u.clock.id = clock_id,
       .u.u.clock.flags = flags,
   };
-  if (!timespec_to_timestamp_clamp(rqtp, &sub.u.u.clock.timeout))
+  if (!timespec_to_timestamp_exact(rqtp, &sub.u.u.clock.timeout))
     return EINVAL;
 
   // Block until polling event is triggered.


### PR DESCRIPTION
commit ffba88fb5737f37202ea53e4dac593f096166765 is applied for curl to work. However, that commit affects clock_nanosleep in the way as reported in #26. timespec_to_timestamp_clamp allows immediate return as *timestamp = 1 shows, resulting in the issue, but timespec_to_timestamp_exact does not allow such a behaviour. Hence we use timespec_to_timestamp_exact for this fix.

Closes: #26