### PR TITLE
Add stubs for common exception tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -541,6 +541,9 @@ $(SYSROOT_LIB)/libwasi-emulated-process-clocks.a: $(LIBWASI_EMULATED_PROCESS_CLO
 
 $(SYSROOT_LIB)/libwasi-emulated-getpid.a: $(LIBWASI_EMULATED_GETPID_OBJS)
 
+$(SYSROOT_LIB)/libcommon-tag-stubs.a: libcommon-tag-stubs.a
+	cp libcommon-tag-stubs.a $@
+
 %.a:
 	@mkdir -p "$(@D)"
 	# On Windows, the commandline for the ar invocation got too long, so it needs to be split up.
@@ -647,7 +650,8 @@ libc: include_dirs \
     $(SYSROOT_LIB)/libc-printscan-no-floating-point.a \
     $(SYSROOT_LIB)/libwasi-emulated-mman.a \
     $(SYSROOT_LIB)/libwasi-emulated-process-clocks.a \
-    $(SYSROOT_LIB)/libwasi-emulated-getpid.a
+    $(SYSROOT_LIB)/libwasi-emulated-getpid.a \
+    $(SYSROOT_LIB)/libcommon-tag-stubs.a
 
 finish: startup_files libc
 	#

--- a/Makefile-eh
+++ b/Makefile-eh
@@ -547,6 +547,9 @@ $(SYSROOT_LIB)/libwasi-emulated-getpid.a: $(LIBWASI_EMULATED_GETPID_OBJS)
 
 $(SYSROOT_LIB)/libsetjmp.a: $(LIBSETJMP_OBJS)
 
+$(SYSROOT_LIB)/libcommon-tag-stubs.a: libcommon-tag-stubs.a
+	cp libcommon-tag-stubs.a $@
+
 %.a:
 	@mkdir -p "$(@D)"
 	# On Windows, the commandline for the ar invocation got too long, so it needs to be split up.
@@ -653,7 +656,8 @@ libc: include_dirs \
     $(SYSROOT_LIB)/libc-printscan-no-floating-point.a \
     $(SYSROOT_LIB)/libwasi-emulated-mman.a \
     $(SYSROOT_LIB)/libwasi-emulated-process-clocks.a \
-    $(SYSROOT_LIB)/libwasi-emulated-getpid.a
+    $(SYSROOT_LIB)/libwasi-emulated-getpid.a \
+    $(SYSROOT_LIB)/libcommon-tag-stubs.a
 
 finish: startup_files libc
 	#

--- a/libcommon-tag-stubs.a
+++ b/libcommon-tag-stubs.a
@@ -1,0 +1,3 @@
+#STUB
+__cpp_exception
+__c_longjmp


### PR DESCRIPTION
Adds a stub library for the `__c_longjmp` and `__cpp_exception` exception tags