### PR TITLE
Adjust includes in ioctl to more closely match musl/glibc

### DIFF
--- a/expected/wasm32-wasi-eh/predefined-macros.txt
+++ b/expected/wasm32-wasi-eh/predefined-macros.txt
@@ -4733,6 +4733,7 @@
 #define TIME_UTC 1
 #define TIME_WAIT 4
 #define TIOCGWINSZ 0x101
+#define TIOCSWINSZ 0x102
 #define TMAGIC "ustar"
 #define TMAGLEN 6
 #define TOEXEC 00001

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -4733,6 +4733,7 @@
 #define TIME_UTC 1
 #define TIME_WAIT 4
 #define TIOCGWINSZ 0x101
+#define TIOCSWINSZ 0x102
 #define TMAGIC "ustar"
 #define TMAGLEN 6
 #define TOEXEC 00001

--- a/expected/wasm64-wasi/predefined-macros.txt
+++ b/expected/wasm64-wasi/predefined-macros.txt
@@ -4731,6 +4731,7 @@
 #define TIME_UTC 1
 #define TIME_WAIT 4
 #define TIOCGWINSZ 0x101
+#define TIOCSWINSZ 0x102
 #define TMAGIC "ustar"
 #define TMAGLEN 6
 #define TOEXEC 00001

--- a/libc-bottom-half/cloudlibc/src/libc/sys/ioctl/ioctl.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/ioctl/ioctl.c
@@ -98,6 +98,26 @@ int ioctl(int fildes, int request, ...) {
       wsz->ws_ypixel = tty.height;
       return 0;
     }
+    case TIOCSWINSZ: {
+      va_list ap;
+      va_start(ap, request);
+      const struct winsize *wsz = va_arg(ap, const struct winsize *);
+      va_end(ap);
+
+      __wasi_tty_t tty;
+      tty.cols = wsz->ws_col;
+      tty.rows = wsz->ws_row;
+      tty.width = wsz->ws_xpixel;
+      tty.height = wsz->ws_ypixel;
+      
+      // Set the updated TTY settings
+      int r = __wasi_tty_set(&tty);
+      if (r != 0) {
+        errno = r;
+        return -1;
+      }
+      return 0;
+    }
     default:
       // Invalid request.
       errno = EINVAL;

--- a/libc-bottom-half/headers/public/__header_sys_ioctl.h
+++ b/libc-bottom-half/headers/public/__header_sys_ioctl.h
@@ -5,6 +5,7 @@
 #define FIONBIO 2
 
 #define TIOCGWINSZ 0x101
+#define TIOCSWINSZ 0x102
 
 #ifdef __cplusplus
 extern "C" {

--- a/libc-bottom-half/headers/public/__header_sys_ioctl.h
+++ b/libc-bottom-half/headers/public/__header_sys_ioctl.h
@@ -10,6 +10,13 @@
 extern "C" {
 #endif
 
+/* MUSL includes these defines */
+#define __NEED_struct_winsize
+#include <bits/alltypes.h>
+#include <bits/ioctl.h>
+/* glibc also includes this one */
+#include <sys/ttydefaults.h>
+
 int ioctl(int, int, ...);
 
 #ifdef __cplusplus


### PR DESCRIPTION
 [`clolcat`](https://github.com/IchMageBaume/clolcat) compiles natively without any problems, but fails when targeting wasix. This is caused by a discrepancy between the includes in wasix-libc and glibc/musl.

Also defines `TIOCSWINSZ` because ncurses fails to build otherwise. 

### Why that program?

I needed a simple C program that was already packaged for Nix for testing purposes last week.
 
 ### Testing
 
I had this patch in my sysroot for the last two weeks, and it didn't break anything. I have not yet tested if setting the terminal size works.