### PR TITLE
Provide mock implementations for the `chown` functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,10 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
         unistd/ualarm.c \
         unistd/ttyname.c \
         unistd/ttyname_r.c \
+        unistd/chown.c \
+        unistd/fchown.c \
+        unistd/fchownat.c \
+        unistd/lchown.c \
         linux/wait3.c \
         linux/wait4.c \
         linux/epoll.c \

--- a/Makefile-eh
+++ b/Makefile-eh
@@ -205,6 +205,10 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
         unistd/ualarm.c \
         unistd/ttyname.c \
         unistd/ttyname_r.c \
+        unistd/chown.c \
+        unistd/fchown.c \
+        unistd/fchownat.c \
+        unistd/lchown.c \
         linux/wait3.c \
         linux/wait4.c \
         linux/epoll.c \

--- a/expected/wasm32-wasi-eh/defined-symbols.txt
+++ b/expected/wasm32-wasi-eh/defined-symbols.txt
@@ -690,6 +690,7 @@ cfsetspeed
 chdir
 chdir_legacy
 chmod
+chown
 cimag
 cimagf
 cimagl
@@ -824,6 +825,8 @@ fabsl
 faccessat
 fchmod
 fchmodat
+fchown
+fchownat
 fclose
 fcntl
 fcvt
@@ -1125,6 +1128,7 @@ kill
 killpg
 l64a
 labs
+lchown
 lckpwdf
 lcong48
 ldexp

--- a/expected/wasm32-wasi-ehpic/defined-symbols.txt
+++ b/expected/wasm32-wasi-ehpic/defined-symbols.txt
@@ -693,6 +693,7 @@ cfsetspeed
 chdir
 chdir_legacy
 chmod
+chown
 cimag
 cimagf
 cimagl
@@ -832,6 +833,8 @@ fabsl
 faccessat
 fchmod
 fchmodat
+fchown
+fchownat
 fclose
 fcntl
 fcvt
@@ -1133,6 +1136,7 @@ kill
 killpg
 l64a
 labs
+lchown
 lckpwdf
 lcong48
 ldexp

--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -690,6 +690,7 @@ cfsetspeed
 chdir
 chdir_legacy
 chmod
+chown
 cimag
 cimagf
 cimagl
@@ -829,6 +830,8 @@ fabsl
 faccessat
 fchmod
 fchmodat
+fchown
+fchownat
 fclose
 fcntl
 fcvt
@@ -1130,6 +1133,7 @@ kill
 killpg
 l64a
 labs
+lchown
 lckpwdf
 lcong48
 ldexp

--- a/libc-top-half/musl/include/unistd.h
+++ b/libc-top-half/musl/include/unistd.h
@@ -89,12 +89,16 @@ ssize_t write(int, const void *, size_t);
 ssize_t pread(int, void *, size_t, off_t);
 ssize_t pwrite(int, const void *, size_t, off_t);
 
-#ifdef __wasilibc_unmodified_upstream /* WASI has no chown */
+// TODO: Actually implement ownership in WASIX
+
+// Only mocked in WASIX. Trying to change ownership to anyone but 0:0 will return ENOSYS.
 int chown(const char *, uid_t, gid_t);
+// Only mocked in WASIX. Trying to change ownership to anyone but 0:0 will return ENOSYS.
 int fchown(int, uid_t, gid_t);
+// Only mocked in WASIX. Trying to change ownership to anyone but 0:0 will return ENOSYS.
 int lchown(const char *, uid_t, gid_t);
+// Only mocked in WASIX. Trying to change ownership to anyone but 0:0 will return ENOSYS.
 int fchownat(int, const char *, uid_t, gid_t, int);
-#endif
 
 int link(const char *, const char *);
 int linkat(int, const char *, int, const char *, int);

--- a/libc-top-half/musl/src/unistd/chown.c
+++ b/libc-top-half/musl/src/unistd/chown.c
@@ -1,12 +1,22 @@
 #include <unistd.h>
+#include <errno.h>
 #include <fcntl.h>
 #include "syscall.h"
 
 int chown(const char *path, uid_t uid, gid_t gid)
 {
+#ifdef __wasilibc_unmodified_upstream /* WASIX has real no ownership yet */
 #ifdef SYS_chown
 	return syscall(SYS_chown, path, uid, gid);
 #else
 	return syscall(SYS_fchownat, AT_FDCWD, path, uid, gid, 0);
+#endif
+#else
+	// TODO: Implement ownership in WASIX
+	if ((uid == 0 || uid == -1) && (gid == 0 || gid == -1))
+		return 0; // No-op for WASIX, all files belong to 0:0
+	// Every operation that would change ownership is not implemented in WASIX
+	errno = ENOSYS;
+	return -1;
 #endif
 }

--- a/libc-top-half/musl/src/unistd/fchown.c
+++ b/libc-top-half/musl/src/unistd/fchown.c
@@ -5,6 +5,7 @@
 
 int fchown(int fd, uid_t uid, gid_t gid)
 {
+#ifdef __wasilibc_unmodified_upstream /* WASIX has real no ownership yet */
 	int ret = __syscall(SYS_fchown, fd, uid, gid);
 	if (ret != -EBADF || __syscall(SYS_fcntl, fd, F_GETFD) < 0)
 		return __syscall_ret(ret);
@@ -15,6 +16,14 @@ int fchown(int fd, uid_t uid, gid_t gid)
 	return syscall(SYS_chown, buf, uid, gid);
 #else
 	return syscall(SYS_fchownat, AT_FDCWD, buf, uid, gid, 0);
+#endif
+#else
+	// TODO: Implement ownership in WASIX
+	if ((uid == 0 || uid == -1) && (gid == 0 || gid == -1))
+		return 0; // No-op for WASIX, all files belong to 0:0
+	// Every operation that would change ownership is not implemented in WASIX
+	errno = ENOSYS;
+	return -1;
 #endif
 
 }

--- a/libc-top-half/musl/src/unistd/fchownat.c
+++ b/libc-top-half/musl/src/unistd/fchownat.c
@@ -1,7 +1,17 @@
 #include <unistd.h>
+#include <errno.h>
 #include "syscall.h"
 
 int fchownat(int fd, const char *path, uid_t uid, gid_t gid, int flag)
 {
+#ifdef __wasilibc_unmodified_upstream /* WASIX has real no ownership yet */
 	return syscall(SYS_fchownat, fd, path, uid, gid, flag);
+#else
+	// TODO: Implement ownership in WASIX
+	if ((uid == 0 || uid == -1) && (gid == 0 || gid == -1))
+		return 0; // No-op for WASIX, all files belong to 0:0
+	// Every operation that would change ownership is not implemented in WASIX
+	errno = ENOSYS;
+	return -1;
+#endif
 }

--- a/libc-top-half/musl/src/unistd/lchown.c
+++ b/libc-top-half/musl/src/unistd/lchown.c
@@ -1,12 +1,22 @@
 #include <unistd.h>
+#include <errno.h>
 #include <fcntl.h>
 #include "syscall.h"
 
 int lchown(const char *path, uid_t uid, gid_t gid)
 {
+#ifdef __wasilibc_unmodified_upstream /* WASIX has real no ownership yet */
 #ifdef SYS_lchown
 	return syscall(SYS_lchown, path, uid, gid);
 #else
 	return syscall(SYS_fchownat, AT_FDCWD, path, uid, gid, AT_SYMLINK_NOFOLLOW);
+#endif
+#else
+	// TODO: Implement ownership in WASIX
+	if ((uid == 0 || uid == -1) && (gid == 0 || gid == -1))
+		return 0; // No-op for WASIX, all files belong to 0:0
+	// Every operation that would change ownership is not implemented in WASIX
+	errno = ENOSYS;
+	return -1;
 #endif
 }


### PR DESCRIPTION
Implement the `chown` family of functions as mocks. We currently don't support ownership, so everything is treated like it belongs to `0:0`. The functions provided by this PR implement changing ownership to `0` or leaving it unchanged. Everything else sets errno to `ENOSYS` and does nothing.