### PR TITLE
Enable getpass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,6 +215,7 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
         ldso/dlsym.c \
         stat/futimesat.c \
         legacy/getpagesize.c \
+        legacy/getpass.c \
         thread/thrd_sleep.c \
         wasix/call_dynamic.c \
         wasix/closure_allocate.c \

--- a/Makefile-eh
+++ b/Makefile-eh
@@ -216,6 +216,7 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
         linux/setgroups.c \
         stat/futimesat.c \
         legacy/getpagesize.c \
+        legacy/getpass.c \
         thread/thrd_sleep.c \
         wasix/call_dynamic.c \
         wasix/closure_allocate.c \

--- a/expected/wasm32-wasi-eh/defined-symbols.txt
+++ b/expected/wasm32-wasi-eh/defined-symbols.txt
@@ -990,6 +990,7 @@ getopt
 getopt_long
 getopt_long_only
 getpagesize
+getpass
 getpeername
 getpgid
 getpgrp

--- a/expected/wasm32-wasi-ehpic/defined-symbols.txt
+++ b/expected/wasm32-wasi-ehpic/defined-symbols.txt
@@ -998,6 +998,7 @@ getopt
 getopt_long
 getopt_long_only
 getpagesize
+getpass
 getpeername
 getpgid
 getpgrp

--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -995,6 +995,7 @@ getopt
 getopt_long
 getopt_long_only
 getpagesize
+getpass
 getpeername
 getpgid
 getpgrp

--- a/libc-top-half/musl/include/unistd.h
+++ b/libc-top-half/musl/include/unistd.h
@@ -237,7 +237,9 @@ int sethostname(const char *, size_t);
 int getdomainname(char *, size_t);
 int setdomainname(const char *, size_t);
 int setgroups(size_t, const gid_t *);
+#endif
 char *getpass(const char *);
+#ifdef __wasilibc_unmodified_upstream
 int daemon(int, int);
 void setusershell(void);
 void endusershell(void);


### PR DESCRIPTION
We currently don't include an implementation for [`getpass`](https://man7.org/linux/man-pages/man3/getpass.3.html).

The implementation provided by this PR is mostly correct, but it does **not** interact with `/dev/tty` but with stdin and stdout. This should work for most basic cases.

I verified that it works with a test in wasix-org/wasix-tests.