### PR TITLE
Provide an implementation for clock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
         time/asctime_r.c \
         time/ctime.c \
         time/ctime_r.c \
+        time/clock.c \
         time/wcsftime.c \
         time/strptime.c \
         time/difftime.c \

--- a/Makefile-eh
+++ b/Makefile-eh
@@ -163,6 +163,7 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
         time/asctime_r.c \
         time/ctime.c \
         time/ctime_r.c \
+        time/clock.c \
         time/wcsftime.c \
         time/strptime.c \
         time/difftime.c \


### PR DESCRIPTION
We currently include the clock() function in our headers, but don't actually provide an implementation. The existing implementation only depends on the other time APIs, so we can just enable it.

I verified that the clock function works in wasix-org/wasix-tests.