### PR TITLE
Disallow fork/vfork in EH configuration, since it's not supported

### DIFF
--- a/expected/wasm32-wasi-eh/defined-symbols.txt
+++ b/expected/wasm32-wasi-eh/defined-symbols.txt
@@ -1,7 +1,6 @@
 _CLOCK_MONOTONIC
 _CLOCK_REALTIME
 _Exit
-_Fork
 _IO_feof_unlocked
 _IO_ferror_unlocked
 _IO_getc
@@ -14,7 +13,6 @@ __SIG_ERR
 __SIG_IGN
 __abort_lock
 __acquire_ptc
-__aio_atfork
 __aio_close
 __asctime_r
 __assert_fail
@@ -32,7 +30,6 @@ __clock
 __clock_gettime
 __clock_nanosleep
 __clock_settime
-__clone
 __cos
 __cosdf
 __cosl
@@ -577,7 +574,6 @@ __year_to_secs
 _environ
 _exit
 _flushlbf
-_fork_internal
 _initialize
 _pthread_cleanup_pop
 _pthread_cleanup_push
@@ -898,7 +894,6 @@ fnmatch
 fopen
 fopen64
 fopencookie
-fork
 fpathconf
 fprintf
 fpurge
@@ -1728,7 +1723,6 @@ vasprintf
 vdprintf
 versionsort
 versionsort64
-vfork
 vfprintf
 vfscanf
 vfwprintf

--- a/expected/wasm32-wasi-ehpic/defined-symbols.txt
+++ b/expected/wasm32-wasi-ehpic/defined-symbols.txt
@@ -1,7 +1,6 @@
 _CLOCK_MONOTONIC
 _CLOCK_REALTIME
 _Exit
-_Fork
 _IO_feof_unlocked
 _IO_ferror_unlocked
 _IO_getc
@@ -14,7 +13,6 @@ __SIG_ERR
 __SIG_IGN
 __abort_lock
 __acquire_ptc
-__aio_atfork
 __aio_close
 __asctime_r
 __assert_fail
@@ -31,7 +29,6 @@ __clock
 __clock_gettime
 __clock_nanosleep
 __clock_settime
-__clone
 __cos
 __cosdf
 __cosl
@@ -580,7 +577,6 @@ __year_to_secs
 _environ
 _exit
 _flushlbf
-_fork_internal
 _initialize
 _pthread_cleanup_pop
 _pthread_cleanup_push
@@ -906,7 +902,6 @@ fnmatch
 fopen
 fopen64
 fopencookie
-fork
 fpathconf
 fprintf
 fpurge
@@ -1736,7 +1731,6 @@ vasprintf
 vdprintf
 versionsort
 versionsort64
-vfork
 vfprintf
 vfscanf
 vfwprintf

--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -31,7 +31,6 @@ __clock
 __clock_gettime
 __clock_nanosleep
 __clock_settime
-__clone
 __cos
 __cosdf
 __cosl

--- a/libc-top-half/musl/include/unistd.h
+++ b/libc-top-half/musl/include/unistd.h
@@ -134,9 +134,11 @@ unsigned sleep(unsigned);
 int pause(void);
 #endif
 
+#if defined(__wasilibc_unmodified_upstream) || !defined(__wasm_exception_handling__)
 pid_t fork(void);
 pid_t _fork_internal(int copy_mem);
 pid_t _Fork(int copy_mem);
+#endif
 int execve(const char *, char *const [], char *const []);
 int execv(const char *, char *const []);
 int execle(const char *, const char *, ...);
@@ -225,7 +227,9 @@ unsigned ualarm(unsigned, unsigned);
 int brk(void *);
 #endif
 void *sbrk(intptr_t);
+#if defined(__wasilibc_unmodified_upstream) || !defined(__wasm_exception_handling__)
 pid_t vfork(void);
+#endif
 #ifdef __wasilibc_unmodified_upstream /* WASI has no processes */
 int vhangup(void);
 int chroot(const char *);

--- a/libc-top-half/musl/src/internal/pthread_impl.h
+++ b/libc-top-half/musl/src/internal/pthread_impl.h
@@ -166,7 +166,9 @@ extern hidden volatile size_t __pthread_tsd_size;
 extern hidden void *__pthread_tsd_main[];
 extern hidden volatile int __eintr_valid_flag;
 
+#if defined(__wasilibc_unmodified_upstream) || !defined(__wasm_exception_handling__)
 hidden int __clone(int (*)(void *), void *, int, void *, ...);
+#endif
 hidden int __set_thread_area(void *);
 #ifdef __wasilibc_unmodified_upstream /* WASI has no sigaction */
 hidden int __libc_sigaction(int, const struct sigaction *, struct sigaction *);

--- a/libc-top-half/musl/src/process/_Fork.c
+++ b/libc-top-half/musl/src/process/_Fork.c
@@ -10,6 +10,8 @@
 #include "pthread_impl.h"
 #include "aio_impl.h"
 
+#if defined(__wasilibc_unmodified_upstream) || !defined(__wasm_exception_handling__)
+
 static void dummy(int x) { }
 weak_alias(dummy, __aio_atfork);
 
@@ -60,3 +62,5 @@ pid_t _Fork(int copy_mem)
 	__restore_sigs(&set);
 	return __syscall_ret(ret);
 }
+
+#endif /* defined(__wasilibc_unmodified_upstream) || !defined(__wasm_exception_handling__) */

--- a/libc-top-half/musl/src/process/fork.c
+++ b/libc-top-half/musl/src/process/fork.c
@@ -51,6 +51,8 @@ weak_alias(dummy_0, __tl_lock);
 weak_alias(dummy_0, __tl_unlock);
 #endif
 
+#if defined(__wasilibc_unmodified_upstream) || !defined(__wasm_exception_handling__)
+
 pid_t fork(void)
 {
 	return _fork_internal(1);
@@ -100,3 +102,5 @@ pid_t _fork_internal(int copy_mem)
 	if (ret<0) errno = errno_save;
 	return ret;
 }
+
+#endif /* defined(__wasilibc_unmodified_upstream) || !defined(__wasm_exception_handling__) */

--- a/libc-top-half/musl/src/process/vfork.c
+++ b/libc-top-half/musl/src/process/vfork.c
@@ -5,6 +5,8 @@
 #include "syscall.h"
 #endif
 
+#if defined(__wasilibc_unmodified_upstream) || !defined(__wasm_exception_handling__)
+
 pid_t vfork(void)
 {
 #ifdef __wasilibc_unmodified_upstream
@@ -18,3 +20,5 @@ pid_t vfork(void)
 	return _fork_internal(0);
 #endif
 }
+
+#endif /* defined(__wasilibc_unmodified_upstream) || !defined(__wasm_exception_handling__) */

--- a/libc-top-half/musl/src/thread/clone.c
+++ b/libc-top-half/musl/src/thread/clone.c
@@ -3,6 +3,8 @@
 #include <unistd.h>
 #include "pthread_impl.h"
 
+// WASIX uses a separate syscall for posix_spawn, so __clone isn't needed
+#if defined(__wasilibc_unmodified_upstream)
 #ifndef CLONE_VFORK
 #define CLONE_VFORK	0x00004000
 #endif
@@ -23,3 +25,4 @@ int __clone(int (*func)(void *), void *stack, int flags, void *arg, ...)
 	}
 	return pid;
 }
+#endif /* defined(__wasilibc_unmodified_upstream) */


### PR DESCRIPTION
This change causes code that uses fork/vfork in EH configuration to fail to compile.

Note that forking requires asyncify. There are two reasons we don't want to asyncify EH modules:
* `wasm-opt` can't asyncify code that uses EH, and
* Avoiding asyncify and the overhead it introduces is EH's raison d'être. It makes little sense to asyncify EH modules even if wasm-opt supported it.

In the spirit of sneaking in changes, this PR also disables `__clone` entirely. `__clone` is used to implement `posix_spawn` in terms of `fork`. Since WASIX uses a separate syscall to back `posix_spawn`, `__clone` is unused in either configuration.