### PR TITLE
Clean up the install target in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -812,10 +812,16 @@ check-symbols: startup_files libc
 install: finish
 	mkdir -p "$(DESTDIR)$(libdir)"
 	cp -rT "$(SYSROOT_LIB)" "$(DESTDIR)$(libdir)"
+
 	mkdir -p "$(DESTDIR)$(includedir)"
 	cp -rT "$(SYSROOT_INC)" "$(DESTDIR)$(includedir)"
-#   mkdir -p "$(DESTDIR)$(datarootdir)"
-#   cp -rT "$(SYSROOT_SHARE)" "$(DESTDIR)$(datarootdir)"
+
+	# mkdir -p "$(DESTDIR)$(datarootdir)"
+	# cp -rT "$(SYSROOT_SHARE)" "$(DESTDIR)$(datarootdir)"
+
+	# For some reason we want this lib when testing symbols, but not when installing?
+	# The oldest I could trace this is https://github.com/wasix-org/wasix-libc/blame/cd4cb2b9d9b030ec27806234198481907ef0d13a/build64.sh#L33-L33C56
+	rm -f "$(DESTDIR)$(libdir)/libc-printscan-long-double.a"
 
 clean:
 	$(RM) -r build

--- a/Makefile-eh
+++ b/Makefile-eh
@@ -829,10 +829,16 @@ check-symbols: startup_files libc
 install: finish
 	mkdir -p "$(DESTDIR)$(libdir)"
 	cp -rT "$(SYSROOT_LIB)" "$(DESTDIR)$(libdir)"
+
 	mkdir -p "$(DESTDIR)$(includedir)"
 	cp -rT "$(SYSROOT_INC)" "$(DESTDIR)$(includedir)"
-#   mkdir -p "$(DESTDIR)$(datarootdir)"
-#   cp -rT "$(SYSROOT_SHARE)" "$(DESTDIR)$(datarootdir)"
+
+	# mkdir -p "$(DESTDIR)$(datarootdir)"
+	# cp -rT "$(SYSROOT_SHARE)" "$(DESTDIR)$(datarootdir)"
+
+	# For some reason we want this lib when testing symbols, but not when installing?
+	# The oldest I could trace this is https://github.com/wasix-org/wasix-libc/blame/cd4cb2b9d9b030ec27806234198481907ef0d13a/build64.sh#L33-L33C56
+	rm -f "$(DESTDIR)$(libdir)/libc-printscan-long-double.a"
 
 clean:
 	$(RM) -r build


### PR DESCRIPTION
This PR adjusts `make install` to support the Makefile conventions for running installing software. It adds support for the relevant [directory variables](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html) and [`DESTDIR`](https://www.gnu.org/prep/standards/html_node/DESTDIR.html).