### PR TITLE
Revert "Switch to WASM atomics for futexes in EH configs"

### DIFF
--- a/expected/wasm32-wasi-eh/defined-symbols.txt
+++ b/expected/wasm32-wasi-eh/defined-symbols.txt
@@ -522,6 +522,8 @@ __wasilibc_find_abspath
 __wasilibc_find_relpath
 __wasilibc_find_relpath_alloc
 __wasilibc_futex_wait
+__wasilibc_futex_wait_wasix
+__wasilibc_futex_wake_wasix
 __wasilibc_get_environ
 __wasilibc_get_stack_pointer
 __wasilibc_get_tls_base

--- a/expected/wasm32-wasi-ehpic/defined-symbols.txt
+++ b/expected/wasm32-wasi-ehpic/defined-symbols.txt
@@ -525,6 +525,8 @@ __wasilibc_find_abspath
 __wasilibc_find_relpath
 __wasilibc_find_relpath_alloc
 __wasilibc_futex_wait
+__wasilibc_futex_wait_wasix
+__wasilibc_futex_wake_wasix
 __wasilibc_get_environ
 __wasilibc_get_stack_pointer
 __wasilibc_get_tls_base

--- a/libc-bottom-half/sources/__wasilibc_futex.c
+++ b/libc-bottom-half/sources/__wasilibc_futex.c
@@ -1,10 +1,3 @@
-// We don't want to ever use the syscall-based futex implementation
-// in EH configurations, since that's mainly useful for journaling
-// and taking snapshots at random points is impossible without
-// module-wide asyncification.
-// Note that syscalls are many times slower than just using WASM atomics.
-#ifndef __wasm_exception_handling__
-
 #include <wasi/api.h>
 #include <sys/types.h>
 #include <limits.h>
@@ -64,5 +57,3 @@ int __wasilibc_futex_wake_wasix(int* futex, int cnt) {
   }
   return 0;
 }
-
-#endif

--- a/libc-top-half/musl/src/internal/pthread_impl.h
+++ b/libc-top-half/musl/src/internal/pthread_impl.h
@@ -176,7 +176,7 @@ hidden int __libc_sigaction(int, const struct sigaction *, struct sigaction *);
 hidden void __unmapself(void *, size_t);
 
 #ifndef __wasilibc_unmodified_upstream
-hidden int __wasilibc_futex_wait(volatile void *, int, int64_t);
+hidden int __wasilibc_futex_wait(volatile void *, int, int, int64_t);
 #endif
 hidden int __timedwait(volatile int *, int, clockid_t, const struct timespec *, int);
 hidden int __timedwait_cp(volatile int *, int, clockid_t, const struct timespec *, int);
@@ -189,12 +189,8 @@ static inline void __wake(volatile void *addr, int cnt, int priv)
 	__syscall(SYS_futex, addr, FUTEX_WAKE|priv, cnt) != -ENOSYS ||
 	__syscall(SYS_futex, addr, FUTEX_WAKE, cnt);
 #else
-// See comments in __wasilibc_futex.c
-#ifdef __wasm_exception_handling__
-	__builtin_wasm_memory_atomic_notify((int*)addr, cnt);
-#else
 	__wasilibc_futex_wake_wasix((int*)addr, cnt);
-#endif
+	//__builtin_wasm_memory_atomic_notify((int*)addr, cnt);
 #endif
 }
 static inline void __futexwait(volatile void *addr, int val, int priv)

--- a/libc-top-half/musl/src/thread/__wait.c
+++ b/libc-top-half/musl/src/thread/__wait.c
@@ -4,12 +4,14 @@
 #endif
 
 #ifndef __wasilibc_unmodified_upstream
-// Use WebAssembly's `wait` instruction to implement a futex. Note that
-// for `max_wait_ns`, -1 (or any negative number) means wait indefinitely.
+// Use WebAssembly's `wait` instruction to implement a futex. Note that `op` is
+// unused but retained as a parameter to match the original signature of the
+// syscall and that, for `max_wait_ns`, -1 (or any negative number) means wait
+// indefinitely.
 //
 // Adapted from Emscripten: see
 // https://github.com/emscripten-core/emscripten/blob/058a9fff/system/lib/pthread/emscripten_futex_wait.c#L111-L150.
-int __wasilibc_futex_wait(volatile void *addr, int val, int64_t max_wait_ns)
+int __wasilibc_futex_wait(volatile void *addr, int op, int val, int64_t max_wait_ns)
 {
     if ((((intptr_t)addr) & 3) != 0) {
         return -EINVAL;
@@ -46,15 +48,10 @@ void __wait(volatile int *addr, volatile int *waiters, int val, int priv)
 		__syscall(SYS_futex, addr, FUTEX_WAIT|priv, val, 0) != -ENOSYS
 		|| __syscall(SYS_futex, addr, FUTEX_WAIT, val, 0);
 #else
-// See comments in __wasilibc_futex.c
-#ifdef __wasm_exception_handling__
-		__wasilibc_futex_wait(addr, val, -1);
-#else
         // we feed the wait operation to a syscall rather than
         // use atomics so that the asyncify and journaling can
         // work properly
 		__wasilibc_futex_wait_wasix(addr, FUTEX_WAIT, val, -1);
-#endif
 #endif
 	}
 	if (waiters) a_dec(waiters);


### PR DESCRIPTION
It turned out #91 sadly breaks the dynamic linker as atomic waits, blocks the waiting thread, but the linker needs all threads to arrive at the synchronization point.

Reverts wasix-org/wasix-libc#91