### PR TITLE
Add sigsetjmp to headers for non-eh builds.

### DIFF
--- a/libc-top-half/musl/include/setjmp.h
+++ b/libc-top-half/musl/include/setjmp.h
@@ -1,5 +1,5 @@
-#ifndef	_SETJMP_H
-#define	_SETJMP_H
+#ifndef _SETJMP_H
+#define _SETJMP_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -8,67 +8,56 @@ extern "C" {
 #include <features.h>
 
 #ifdef __wasilibc_unmodified_upstream
-#include <bits/setjmp.h>
+    // Native setjmp/longjmp
+    #include <bits/setjmp.h>
 
-typedef struct __jmp_buf_tag {
-	__jmp_buf __jb;
-	unsigned long __fl;
-	unsigned long __ss[128/sizeof(long)];
-} jmp_buf[1];
+    typedef struct __jmp_buf_tag {
+        __jmp_buf __jb;
+        unsigned long __fl;
+        unsigned long __ss[128/sizeof(long)];
+    } jmp_buf[1];
 
-#if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) \
- || defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
- || defined(_BSD_SOURCE)
-typedef jmp_buf sigjmp_buf;
-int sigsetjmp (sigjmp_buf, int);
-_Noreturn void siglongjmp (sigjmp_buf, int);
-#endif
-
-#if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
- || defined(_BSD_SOURCE)
-int _setjmp (jmp_buf);
-_Noreturn void _longjmp (jmp_buf, int);
-#endif
 #elif defined(__wasm_exception_handling__)
+    // EH-based setjmp/longjmp
     typedef int __jmp_buf[6];
 
-	typedef struct __jmp_buf_tag
-	{
-		__jmp_buf __jb;
-		unsigned long __fl;
-		unsigned long __ss[128 / sizeof(long)];
-	} jmp_buf[1];
-
-#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1)
-#define __setjmp_attr __attribute__((__returns_twice__))
+    typedef struct __jmp_buf_tag
+    {
+        __jmp_buf __jb;
+        unsigned long __fl;
+        unsigned long __ss[128 / sizeof(long)];
+    } jmp_buf[1];
 #else
-#define __setjmp_attr
+    // asyncify-based setjmp/longjmp
+    #include <wasi/api.h>
+    typedef __wasi_stack_snapshot_t __jmp_buf_tag;
+    typedef __wasi_stack_snapshot_t jmp_buf[1];
+    typedef jmp_buf sigjmp_buf;
 #endif
 
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 1)
+    #define __setjmp_attr __attribute__((__returns_twice__))
+#else
+    #define __setjmp_attr
+#endif
+
+int setjmp (jmp_buf) __setjmp_attr;
+_Noreturn void longjmp (jmp_buf, int);
+#define setjmp setjmp
+
 #if defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE) || \
-	defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
-	typedef jmp_buf sigjmp_buf;
-	int sigsetjmp(sigjmp_buf, int) __setjmp_attr;
-	_Noreturn void siglongjmp(sigjmp_buf, int);
+    defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+    typedef jmp_buf sigjmp_buf;
+    int sigsetjmp(sigjmp_buf, int) __setjmp_attr;
+    _Noreturn void siglongjmp(sigjmp_buf, int);
 #endif
 
 #if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
-	int _setjmp(jmp_buf) __setjmp_attr;
-	_Noreturn void _longjmp(jmp_buf, int);
+    int _setjmp(jmp_buf) __setjmp_attr;
+    _Noreturn void _longjmp(jmp_buf, int);
 #endif
 
 #undef __setjmp_attr
-#else
-#include <wasi/api.h>
-typedef __wasi_stack_snapshot_t __jmp_buf_tag;
-typedef __wasi_stack_snapshot_t jmp_buf[1];
-typedef jmp_buf sigjmp_buf;
-#endif
-
-int setjmp (jmp_buf);
-_Noreturn void longjmp (jmp_buf, int);
-
-#define setjmp setjmp
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The non-eh builds already include the sigsetjmp symbol, but don't declare it in the headers. This PR fixes that and performs minor restructuring in `setjmp.h` to improve readability.

Keep in mind that our `sigsetjmp` is just a dummy implementation that calls normal `setjmp`.