### PR TITLE
Add `proc_raise_interval2`

### DIFF
--- a/libc-bottom-half/headers/public/wasi/api_wasix.h
+++ b/libc-bottom-half/headers/public/wasi/api_wasix.h
@@ -3842,6 +3842,21 @@ _Static_assert(sizeof(__wasi_context_id_t) == 8, "witx calculated size");
 _Static_assert(_Alignof(__wasi_context_id_t) == 8, "witx calculated align");
 
 /**
+ * Signal action.
+ */
+typedef struct __wasi_itimerval_t {
+    __wasi_timestamp_t tv_sec;
+
+    __wasi_timestamp_t tv_usec;
+
+} __wasi_itimerval_t;
+
+_Static_assert(sizeof(__wasi_itimerval_t) == 16, "witx calculated size");
+_Static_assert(_Alignof(__wasi_itimerval_t) == 8, "witx calculated align");
+_Static_assert(offsetof(__wasi_itimerval_t, tv_sec) == 0, "witx calculated offset");
+_Static_assert(offsetof(__wasi_itimerval_t, tv_usec) == 8, "witx calculated offset");
+
+/**
  * @defgroup wasix_32v1
  * @{
  */
@@ -4178,6 +4193,22 @@ __wasi_errno_t __wasi_proc_raise_interval(
      * Flag that indicates if the signal will trigger indefinately
      */
     __wasi_bool_t repeat
+) __attribute__((__warn_unused_result__));
+/**
+ * Send a signal to the process of the calling thread on a regular basis
+ * Note: This is similar to `setitimer` in POSIX.
+ */
+__wasi_errno_t __wasi_proc_raise_interval2(
+    /**
+     * The signal condition to trigger.
+     */
+    __wasi_signal_t sig,
+    /**
+     * Time to wait before raising the signal
+     * (zero here indicates the signal interval is cancelled)
+     */
+    const __wasi_itimerval_t * now,
+    __wasi_itimerval_t *retptr0
 ) __attribute__((__warn_unused_result__));
 /**
  * Forks the current process into a new subprocess. If the function

--- a/libc-bottom-half/headers/public/wasi/api_wasix.h
+++ b/libc-bottom-half/headers/public/wasi/api_wasix.h
@@ -3841,20 +3841,32 @@ typedef uint64_t __wasi_context_id_t;
 _Static_assert(sizeof(__wasi_context_id_t) == 8, "witx calculated size");
 _Static_assert(_Alignof(__wasi_context_id_t) == 8, "witx calculated align");
 
-/**
- * Signal action.
- */
-typedef struct __wasi_itimerval_t {
+typedef struct __wasi_timeval_t {
     __wasi_timestamp_t tv_sec;
 
     __wasi_timestamp_t tv_usec;
 
+} __wasi_timeval_t;
+
+_Static_assert(sizeof(__wasi_timeval_t) == 16, "witx calculated size");
+_Static_assert(_Alignof(__wasi_timeval_t) == 8, "witx calculated align");
+_Static_assert(offsetof(__wasi_timeval_t, tv_sec) == 0, "witx calculated offset");
+_Static_assert(offsetof(__wasi_timeval_t, tv_usec) == 8, "witx calculated offset");
+
+/**
+ * Signal action.
+ */
+typedef struct __wasi_itimerval_t {
+    __wasi_timeval_t it_interval;
+
+    __wasi_timeval_t it_value;
+
 } __wasi_itimerval_t;
 
-_Static_assert(sizeof(__wasi_itimerval_t) == 16, "witx calculated size");
+_Static_assert(sizeof(__wasi_itimerval_t) == 32, "witx calculated size");
 _Static_assert(_Alignof(__wasi_itimerval_t) == 8, "witx calculated align");
-_Static_assert(offsetof(__wasi_itimerval_t, tv_sec) == 0, "witx calculated offset");
-_Static_assert(offsetof(__wasi_itimerval_t, tv_usec) == 8, "witx calculated offset");
+_Static_assert(offsetof(__wasi_itimerval_t, it_interval) == 0, "witx calculated offset");
+_Static_assert(offsetof(__wasi_itimerval_t, it_value) == 16, "witx calculated offset");
 
 /**
  * @defgroup wasix_32v1

--- a/libc-bottom-half/sources/__wasixlibc_real.c
+++ b/libc-bottom-half/sources/__wasixlibc_real.c
@@ -355,6 +355,20 @@ __wasi_errno_t __wasi_proc_raise_interval(
     return (uint16_t) ret;
 }
 
+int32_t __imported_wasix_32v1_proc_raise_interval2(int32_t arg0, int32_t arg1, int32_t arg2) __attribute__((
+    __import_module__("wasix_32v1"),
+    __import_name__("proc_raise_interval2")
+));
+
+__wasi_errno_t __wasi_proc_raise_interval2(
+    __wasi_signal_t sig,
+    const __wasi_itimerval_t * now,
+    __wasi_itimerval_t *retptr0
+){
+    int32_t ret = __imported_wasix_32v1_proc_raise_interval2((int32_t) sig, (int32_t) now, (intptr_t) retptr0);
+    return (uint16_t) ret;
+}
+
 int32_t __imported_wasix_32v1_proc_fork(int32_t arg0, int32_t arg1) __attribute__((
     __import_module__("wasix_32v1"),
     __import_name__("proc_fork")

--- a/libc-top-half/musl/src/signal/setitimer.c
+++ b/libc-top-half/musl/src/signal/setitimer.c
@@ -29,9 +29,7 @@ int setitimer(int which, const struct itimerval *restrict new, struct itimerval 
 	}
 	return syscall(SYS_setitimer, which, new, old);
 #else
-	__wasi_timestamp_t ts = (new->it_interval.tv_sec * (time_t)1000000000) + (new->it_interval.tv_usec * 1000);
-
-	int ret = __wasi_proc_raise_interval((__wasi_signal_t)__WASI_SIGNAL_ALRM, ts, __WASI_BOOL_TRUE);
+	int ret = __wasi_proc_raise_interval2((__wasi_signal_t)__WASI_SIGNAL_ALRM, (const __wasi_itimerval_t *) new, (__wasi_itimerval_t *)old);
 	if (ret != 0) {
 		errno = ret;
 		return -1;


### PR DESCRIPTION

Adds the `proc_raise_interval2` syscall and fixes the `setitimer` (also `alarm`).
Related PRs/issues:
1. PR that implements [proc_raise_interval2](https://github.com/wasmerio/wasmer/pull/6309).
2. Partially fixes [this issue](https://github.com/wasmerio/wasmer/issues/5907).
3. Fixes [this issue].(https://github.com/wasmerio/wasmer/issues/6284)

Note that the PR is still draft since the WASIX headers need to be updated as well.