### PR TITLE
fix: Fix Wasix signal stubs to follow libc errno conventions

### DIFF
--- a/libc-top-half/musl/src/signal/getitimer.c
+++ b/libc-top-half/musl/src/signal/getitimer.c
@@ -1,8 +1,6 @@
 #include <sys/time.h>
 #include <errno.h>
-#ifdef __wasilibc_unmodified_upstream
 #include "syscall.h"
-#endif
 
 int getitimer(int which, struct itimerval *old)
 {
@@ -20,6 +18,8 @@ int getitimer(int which, struct itimerval *old)
 	}
 	return syscall(SYS_getitimer, which, old);
 #else
-	return EINVAL;
+	(void)which;
+	(void)old;
+	return __syscall_ret(-EINVAL);
 #endif
 }

--- a/libc-top-half/musl/src/signal/kill.c
+++ b/libc-top-half/musl/src/signal/kill.c
@@ -1,7 +1,6 @@
 #include <signal.h>
-#ifdef __wasilibc_unmodified_upstream
 #include "syscall.h"
-#else
+#ifndef __wasilibc_unmodified_upstream
 #include <wasi/api.h>
 #endif
 
@@ -11,6 +10,6 @@ int kill(pid_t pid, int sig)
 	return syscall(SYS_kill, pid, sig);
 #else
 	int r = __wasi_proc_signal(pid, (__wasi_signal_t)sig);
-	return r;
+	return __syscall_ret(-r);
 #endif
 }

--- a/libc-top-half/musl/src/signal/raise.c
+++ b/libc-top-half/musl/src/signal/raise.c
@@ -1,8 +1,7 @@
 #include <signal.h>
 #include <stdint.h>
-#ifdef __wasilibc_unmodified_upstream
 #include "syscall.h"
-#else
+#ifndef __wasilibc_unmodified_upstream
 #include <wasi/api.h>
 #endif
 #include "pthread_impl.h"
@@ -21,5 +20,5 @@ int raise(int sig)
 #ifdef __wasilibc_unmodified_upstream
 	__restore_sigs(&set);
 #endif
-	return ret;
+	return __syscall_ret(-ret);
 }

--- a/libc-top-half/musl/src/signal/sigaltstack.c
+++ b/libc-top-half/musl/src/signal/sigaltstack.c
@@ -1,8 +1,6 @@
 #include <signal.h>
 #include <errno.h>
-#ifdef __wasilibc_unmodified_upstream
 #include "syscall.h"
-#endif
 
 int sigaltstack(const stack_t *restrict ss, stack_t *restrict old)
 {
@@ -19,6 +17,6 @@ int sigaltstack(const stack_t *restrict ss, stack_t *restrict old)
 	}
 	return syscall(SYS_sigaltstack, ss, old);
 #else
-	return EINVAL;
+	return __syscall_ret(-EINVAL);
 #endif
 }

--- a/libc-top-half/musl/src/signal/sigpending.c
+++ b/libc-top-half/musl/src/signal/sigpending.c
@@ -1,14 +1,13 @@
 #include <signal.h>
 #include <errno.h>
-#ifdef __wasilibc_unmodified_upstream
 #include "syscall.h"
-#endif
 
 int sigpending(sigset_t *set)
 {
 #ifdef __wasilibc_unmodified_upstream
 	return syscall(SYS_rt_sigpending, set, _NSIG/8);
 #else
-	return EINVAL;
+	(void)set;
+	return __syscall_ret(-EINVAL);
 #endif
 }

--- a/libc-top-half/musl/src/signal/sigqueue.c
+++ b/libc-top-half/musl/src/signal/sigqueue.c
@@ -1,9 +1,7 @@
 #include <signal.h>
 #include <string.h>
 #include <unistd.h>
-#ifdef __wasilibc_unmodified_upstream
 #include "syscall.h"
-#endif
 #include "pthread_impl.h"
 
 int sigqueue(pid_t pid, int sig, const union sigval value)
@@ -23,10 +21,10 @@ int sigqueue(pid_t pid, int sig, const union sigval value)
 #ifdef __wasilibc_unmodified_upstream
 	r = syscall(SYS_rt_sigqueueinfo, pid, sig, &si);
 #else
-    r = EINVAL;
+	r = -EINVAL;
 #endif
 #ifdef __wasilibc_unmodified_upstream
 	__restore_sigs(&set);
 #endif
-	return r;
+	return __syscall_ret(r);
 }

--- a/libc-top-half/musl/src/signal/sigsuspend.c
+++ b/libc-top-half/musl/src/signal/sigsuspend.c
@@ -1,14 +1,13 @@
 #include <signal.h>
 #include <errno.h>
-#ifdef __wasilibc_unmodified_upstream
 #include "syscall.h"
-#endif
 
 int sigsuspend(const sigset_t *mask)
 {
 #ifdef __wasilibc_unmodified_upstream
 	return syscall_cp(SYS_rt_sigsuspend, mask, _NSIG/8);
 #else
-	return EINVAL;
+	(void)mask;
+	return __syscall_ret(-EINVAL);
 #endif
 }

--- a/libc-top-half/musl/src/signal/sigtimedwait.c
+++ b/libc-top-half/musl/src/signal/sigtimedwait.c
@@ -1,8 +1,6 @@
 #include <signal.h>
 #include <errno.h>
-#ifdef __wasilibc_unmodified_upstream
 #include "syscall.h"
-#endif
 
 #define IS32BIT(x) !((x)+0x80000000ULL>>32)
 #define CLAMP(x) (int)(IS32BIT(x) ? (x) : 0x7fffffffU+((0ULL+(x))>>63))
@@ -38,6 +36,9 @@ int sigtimedwait(const sigset_t *restrict mask, siginfo_t *restrict si, const st
 #else
 int sigtimedwait(const sigset_t *restrict mask, siginfo_t *restrict si, const struct timespec *restrict timeout)
 {
-	return EINVAL;
+	(void)mask;
+	(void)si;
+	(void)timeout;
+	return __syscall_ret(-EINVAL);
 }
 #endif

--- a/libc-top-half/musl/src/unistd/setpgrp.c
+++ b/libc-top-half/musl/src/unistd/setpgrp.c
@@ -1,5 +1,6 @@
 #include <unistd.h>
 #include <errno.h>
+#include "syscall.h"
 
 #ifndef __wasilibc_unmodified_upstream
 extern int __wasilibc_pgrp;
@@ -10,7 +11,6 @@ pid_t setpgrp(void)
 #ifdef __wasilibc_unmodified_upstream
 	return setpgid(0, 0);
 #else
-  errno = ENOSYS;
-  return __wasilibc_pgrp;
+	return __syscall_ret(-ENOSYS);
 #endif
 }


### PR DESCRIPTION
This fixes several Wasix libc signal/process stubs that were returning raw errno values or otherwise violating libc/POSIX error conventions. Callers like CPython assume libc semantics on failure. Returning a positive errno directly can surface misleading errors from stale `errno` state.

Changes:
- normalize Wasix signal/process error returns through `__syscall_ret(...)`
- fix unsupported stubs to fail as `-1` with `errno` set
- fix direct Wasix signal wrappers that previously returned raw WASI errno values

Affected APIs:
- `sigaltstack`
- `kill`
- `raise`
- `sigqueue`
- `sigpending`
- `sigsuspend`
- `getitimer`
- `sigtimedwait`
- `setpgrp`

We found this through CPython `faulthandler` startup failures under Wasmer. Guest-side repro showed:
- `sigaltstack(...)` returned `28` (`EINVAL`) directly
- `errno` remained `0`

That violates libc conventions. CPython then treated the call as a generic failure and raised from stale `errno`, which surfaced as:
`OSError: [Errno 61] Value too large for data type`

