### PR TITLE
Set main thread ID to non-conflicting high value

### DIFF
--- a/libc-top-half/musl/src/env/__init_tls.c
+++ b/libc-top-half/musl/src/env/__init_tls.c
@@ -111,8 +111,9 @@ int __init_tp(void *p)
 	 *   of TIDs are 0.
 	 * - pthread mutex owner tracking reserves 0x3fffffff as the
 	 *   "not recoverable" sentinel.
+         * - revert to using good old method
 	 */
-	td->tid = 0x20000000;
+	td->tid = 0x3ffffffe;
 
 	if (&__stack_high) {
 		td->stack = &__stack_high;


### PR DESCRIPTION
## Summary

See also: https://github.com/wasmerio/wasmer/pull/6616

Update WASIX signal delivery to recognize `0x3ffffffe` as the synthetic libc main-thread TID and map it to the Wasmer process/main thread ID.

## Motivation

WASIX libc needs a stable, non-zero `pthread_self()->tid` for the main thread, because the main thread is not created through `thread_spawn` and therefore does not naturally receive a host-allocated WASIX thread ID.

Historically, libc used `0x3fffffff` for this synthetic main-thread TID. Wasmer’s signal delivery path mirrored that convention by remapping `0x3fffffff` to the process/main thread ID before delivering signals.

However, `0x3fffffff` also conflicts with musl’s robust mutex encoding. In the current musl mutex implementation, the low 30 bits of `_m_lock` store the owner TID, and `0x3fffffff` is reserved as the `ENOTRECOVERABLE` sentinel. If the main thread also uses `0x3fffffff` as its TID, mutex ownership can be misinterpreted as an unrecoverable robust mutex state.

Using `0x3ffffffe` preserves the intent of a reserved synthetic main-thread TID while avoiding the musl mutex sentinel.

## Context

The main-thread TID workaround comes from WASI libc’s handling of `pthread_self()` for the main thread:

- https://github.com/WebAssembly/wasi-libc/pull/360
- https://github.com/WebAssembly/wasi-threads/issues/15

The robust mutex sentinel behavior came from the musl 1.1.22 update:

- https://github.com/wasix-org/wasix-libc/commit/f41256b60274f4db25da179c05e4ce844c4cfee2

The conflict was exposed when wasix-libc changed the main-thread TID away from `0x3fffffff` to avoid `ENOTRECOVERABLE` mutex failures:

- https://github.com/wasix-org/wasix-libc/commit/02a107858d09f4eecfb318f89bfd6065fa0d8667

Without the matching Wasmer-side remap, `raise()` sends `__pthread_self()->tid` to `thread_signal`; if that synthetic TID is not mapped to the real main Wasmer thread, the signal is lost. This caused failures in:

```sh
cargo test --test wasm_tests wasm/context_switching/contexts_with_signals