### PR TITLE
macOS build scripts adjustments

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -14,8 +14,8 @@ make clean-all
 mkdir -p ~/.wasix-sysroot
 rsync -Lrtv --delete ./sysroot32/ ~/.wasix-sysroot/sysroot
 rsync -Lrtv --delete ./sysroot32-eh/ ~/.wasix-sysroot/sysroot-eh
-rsync -Lrtv --delete ./sysroot32-eh/ ~/.wasix-sysroot/sysroot-exnref-eh
+rsync -Lrtv --delete ./sysroot32-exnref-eh/ ~/.wasix-sysroot/sysroot-exnref-eh
 rsync -Lrtv --delete ./sysroot32-ehpic/ ~/.wasix-sysroot/sysroot-ehpic
-rsync -Lrtv --delete ./sysroot32-ehpic/ ~/.wasix-sysroot/sysroot-exnref-ehpic
+rsync -Lrtv --delete ./sysroot32-exnref-ehpic/ ~/.wasix-sysroot/sysroot-exnref-ehpic
 
 echo Done!

--- a/build32-general.sh
+++ b/build32-general.sh
@@ -50,6 +50,16 @@ sysroot_output="sysroot$NAME"
 export TARGET_ARCH=wasm32
 export TARGET_OS=wasix
 
+sed_in_place() {
+    local expr="$1"
+    local file="$2"
+    local tmp
+
+    tmp="$(mktemp "${file}.XXXXXX")"
+    sed "$expr" "$file" > "$tmp"
+    mv "$tmp" "$file"
+}
+
 
 ### Build steps
 
@@ -111,8 +121,8 @@ prepare_wasix_libc() {
     # Build the extensions
     cargo run --manifest-path tools/wasix-headers/Cargo.toml generate-libc
     cp -f libc-bottom-half/headers/public/wasi/api.h libc-bottom-half/headers/public/wasi/api_wasix.h
-    sed -i 's|__wasi__|__wasix__|g' libc-bottom-half/headers/public/wasi/api_wasix.h
-    sed -i 's|__wasi_api_h|__wasix_api_h|g' libc-bottom-half/headers/public/wasi/api_wasix.h
+    sed_in_place 's|__wasi__|__wasix__|g' libc-bottom-half/headers/public/wasi/api_wasix.h
+    sed_in_place 's|__wasi_api_h|__wasix_api_h|g' libc-bottom-half/headers/public/wasi/api_wasix.h
     cp -f libc-bottom-half/sources/__wasilibc_real.c libc-bottom-half/sources/__wasixlibc_real.c
     
     # Build WASI

--- a/build64.sh
+++ b/build64.sh
@@ -2,6 +2,16 @@
 
 set -Eeuxo pipefail
 
+sed_in_place() {
+    local expr="$1"
+    local file="$2"
+    local tmp
+
+    tmp="$(mktemp "${file}.XXXXXX")"
+    sed "$expr" "$file" > "$tmp"
+    mv "$tmp" "$file"
+}
+
 export TARGET_ARCH=wasm64
 export TARGET_OS=wasix
 cd tools/wasix-headers/WASI
@@ -12,8 +22,8 @@ cd ../../..
 # Build the extensions
 cargo run --manifest-path tools/wasix-headers/Cargo.toml generate-libc --64bit
 cp -f libc-bottom-half/headers/public/wasi/api.h libc-bottom-half/headers/public/wasi/api_wasix.h
-sed -i 's|__wasi__|__wasix__|g' libc-bottom-half/headers/public/wasi/api_wasix.h
-sed -i 's|__wasi_api_h|__wasix_api_h|g' libc-bottom-half/headers/public/wasi/api_wasix.h
+sed_in_place 's|__wasi__|__wasix__|g' libc-bottom-half/headers/public/wasi/api_wasix.h
+sed_in_place 's|__wasi_api_h|__wasix_api_h|g' libc-bottom-half/headers/public/wasi/api_wasix.h
 cp -f libc-bottom-half/sources/__wasilibc_real.c libc-bottom-half/sources/__wasixlibc_real.c
 
 # Build WASI
@@ -21,8 +31,8 @@ mkdir -p build/temp
 rsync -rtvu --delete tools/wasix-headers/ build/temp
 cp -r -f tools/wasi-headers/WASI/phases/* build/temp/WASI/phases
 mv -f build/temp/WASI/phases/snapshot/witx/wasi_snapshot_preview1.witx build/temp/WASI/phases/snapshot/witx/wasix_v1.witx
-sed -i 's|(field $buf_len $size)|(field $buf_len usize)|g' build/temp/WASI/phases/snapshot/witx/typenames.witx
-sed -i 's|(param $buf_len $size)|(param $buf_len usize)|g' build/temp/WASI/phases/snapshot/witx/wasix_v1.witx
+sed_in_place 's|(field $buf_len $size)|(field $buf_len usize)|g' build/temp/WASI/phases/snapshot/witx/typenames.witx
+sed_in_place 's|(param $buf_len $size)|(param $buf_len usize)|g' build/temp/WASI/phases/snapshot/witx/wasix_v1.witx
 cargo clean --manifest-path build/temp/Cargo.toml
 cargo run --manifest-path build/temp/Cargo.toml generate-libc --64bit
 cp -f libc-bottom-half/headers/public/wasi/api.h libc-bottom-half/headers/public/wasi/api_wasi.h


### PR DESCRIPTION
Allow build scripts to build on macOS with additional adjustment:

```sh
rsync -Lrtv --delete ./sysroot32-exnref-eh/ ~/.wasix-sysroot/sysroot-exnref-eh
rsync -Lrtv --delete ./sysroot32-exnref-ehpic/ ~/.wasix-sysroot/sysroot-exnref-ehpic
```