### PR TITLE
Loopback Reverse Lookup

### DIFF
--- a/libc-top-half/musl/src/network/getnameinfo.c
+++ b/libc-top-half/musl/src/network/getnameinfo.c
@@ -83,19 +83,25 @@ static void reverse_hosts(char *buf, const unsigned char *a, unsigned scopeid, i
 
 static void reverse_loopback(char *buf, const unsigned char *a, unsigned scopeid, int family)
 {
-	static const unsigned char loopback4[4] = { 127, 0, 0, 1 };
-	static const unsigned char loopback6[16] = { [15] = 1 };
+    static const unsigned char loopback4[4] = { 127, 0, 0, 1 };
+    static const unsigned char loopback6[16] = { [15] = 1 };
+    static const unsigned char v4mapped[12] =
+        "\0\0\0\0\0\0\0\0\0\0\xff\xff";
 
-	switch (family) {
-	case AF_INET:
-		if (!memcmp(a, loopback4, sizeof loopback4))
-			strcpy(buf, "localhost");
-		break;
-	case AF_INET6:
-		if (!scopeid && !memcmp(a, loopback6, sizeof loopback6))
-			strcpy(buf, "localhost");
-		break;
-	}
+    (void)scopeid;
+
+    switch (family) {
+    case AF_INET:
+        if (!memcmp(a, loopback4, sizeof loopback4))
+            strcpy(buf, "localhost");
+        break;
+    case AF_INET6:
+        if (!memcmp(a, loopback6, sizeof loopback6) ||
+            (!memcmp(a, v4mapped, sizeof v4mapped) &&
+             !memcmp(a + 12, loopback4, sizeof loopback4)))
+            strcpy(buf, "localhost");
+        break;
+    }
 }
 
 static void reverse_services(char *buf, int port, int dgram)

--- a/libc-top-half/musl/src/network/getnameinfo.c
+++ b/libc-top-half/musl/src/network/getnameinfo.c
@@ -85,8 +85,7 @@ static void reverse_loopback(char *buf, const unsigned char *a, unsigned scopeid
 {
     static const unsigned char loopback4[4] = { 127, 0, 0, 1 };
     static const unsigned char loopback6[16] = { [15] = 1 };
-    static const unsigned char v4mapped[12] =
-        "\0\0\0\0\0\0\0\0\0\0\xff\xff";
+    static const unsigned char v4mapped[12] = { [10] = '\xff', [11] = '\xff' };
 
     (void)scopeid;
 

--- a/libc-top-half/musl/src/network/getnameinfo.c
+++ b/libc-top-half/musl/src/network/getnameinfo.c
@@ -81,6 +81,23 @@ static void reverse_hosts(char *buf, const unsigned char *a, unsigned scopeid, i
 	__fclose_ca(f);
 }
 
+static void reverse_loopback(char *buf, const unsigned char *a, unsigned scopeid, int family)
+{
+	static const unsigned char loopback4[4] = { 127, 0, 0, 1 };
+	static const unsigned char loopback6[16] = { [15] = 1 };
+
+	switch (family) {
+	case AF_INET:
+		if (!memcmp(a, loopback4, sizeof loopback4))
+			strcpy(buf, "localhost");
+		break;
+	case AF_INET6:
+		if (!scopeid && !memcmp(a, loopback6, sizeof loopback6))
+			strcpy(buf, "localhost");
+		break;
+	}
+}
+
 static void reverse_services(char *buf, int port, int dgram)
 {
 	unsigned long svport;
@@ -152,6 +169,7 @@ int getnameinfo(const struct sockaddr *restrict sa, socklen_t sl,
 		buf[0] = 0;
 		if (!(flags & NI_NUMERICHOST)) {
 			reverse_hosts(buf, a, scopeid, af);
+			if (!*buf) reverse_loopback(buf, a, scopeid, af);
 		}
 #ifdef __wasi_unmodified_upstream
 		if (!*buf && !(flags & NI_NUMERICHOST)) {


### PR DESCRIPTION
Why this is a problem:

In the baseline resolver path, getnameinfo() can fail to return localhost for IPv4 or IPv6 loopback addresses. That pushes guests toward hard-coded application-level loopback answers, which is the wrong layer. A POSIX-like libc should provide ordinary loopback reverse lookup behavior itself, using /etc/hosts where available and a small loopback fallback where appropriate.

The fix will make getnameinfo() recognize loopback addresses by family and return localhost when no hosts-file result has already filled the name.

[Detailed documentation](https://github.com/wasmerio/edgejs/blob/test-wasix-quickjs-only/plans/wasix-plan/wasix-libc/05_loopback_reverse_lookup.md)