### PR TITLE
Boolean Socket Option Pointer Handling

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/sys/socket/setsockopt.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/socket/setsockopt.c
@@ -34,7 +34,7 @@ int setsockopt(int socket, int level, int option_name, const void *restrict opti
     case SO_MCASTLOOPV6:
     case SO_KEEPALIVE: {
       __wasi_bool_t on = 0;
-      if (option_value == NULL || option_len < sizeof(int)) {
+      if (option_len < sizeof(int)) {
         errno = EINVAL;
         return -1;
       }

--- a/libc-bottom-half/cloudlibc/src/libc/sys/socket/setsockopt.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/socket/setsockopt.c
@@ -34,12 +34,11 @@ int setsockopt(int socket, int level, int option_name, const void *restrict opti
     case SO_MCASTLOOPV6:
     case SO_KEEPALIVE: {
       __wasi_bool_t on = 0;
-      if (option_len >= sizeof(int)) {
-		 on = *((int*)&option_value) > 0 ? __WASI_BOOL_TRUE : __WASI_BOOL_FALSE;
-	  } else {
-		errno = EINVAL;
-    	return -1;
-	  }
+      if (option_value == NULL || option_len < sizeof(int)) {
+        errno = EINVAL;
+        return -1;
+      }
+      on = (*(const int *)option_value) != 0 ? __WASI_BOOL_TRUE : __WASI_BOOL_FALSE;
 
       __wasi_errno_t error = __wasi_sock_set_opt_flag(socket, option_name, on);
       if (error != 0) {


### PR DESCRIPTION
In the baseline libc socket option wrapper, setsockopt() can treat optval as the option value instead of reading the integer stored at optval. That makes boolean options depend on the pointer address. Since a valid stack pointer is almost always nonzero, a caller trying to set an option to 0 can accidentally set it to 1.

The fix will make libc validate optlen, copy the pointed-to integer, and pass that integer's boolean meaning to the WASIX socket option syscall.

[Detailed description](https://github.com/wasmerio/edgejs/blob/test-wasix-quickjs-only/plans/wasix-plan/wasix-libc/02_boolean_socket_option_pointer_handling.md#boolean-socket-option-pointer-handling)