### PR TITLE
Last Socket Error / SO_ERROR (part 1: LibC)

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/sys/socket/getsockopt.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/socket/getsockopt.c
@@ -46,7 +46,14 @@ int getsockopt(int socket, int level, int option_name,
       return 0;
     }
     case SO_ERROR: {
-      int value = 0;
+      __wasi_filesize_t fs;
+      __wasi_errno_t error = __wasi_sock_get_opt_size(socket, option_name, &fs);
+      if (error != 0) {
+        errno = error;
+        return -1;
+      }
+
+      int value = fs;
       memcpy(option_value, &value, *option_len < sizeof(int) ? *option_len : sizeof(int));
       *option_len = sizeof(int);
       return 0;


### PR DESCRIPTION
In the baseline runtime, the socket operation that actually fails and the later getsockopt(SO_ERROR) call can be disconnected from each other. A nonblocking connect can fail with ECONNREFUSED, but if Wasmer does not record that error on the socket object, the next SO_ERROR read can return success or a generic error.

The visible result is wrong POSIX error reporting. Code that expects ECONNREFUSED may instead see EPIPE, ECONNRESET, or no pending error at all. The fix will store the last socket error in Wasmer socket state and expose that state through the WASIX Sockoption::LastError path used by getsockopt(SO_ERROR).

[Detailed description](https://github.com/wasmerio/edgejs/blob/test-wasix-quickjs-only/plans/wasix-plan/wasmer/03_last_socket_error_so_error.md#last-socket-error--so_error)

This is part 1 of the solution, and second part is in wasmer.