### PR TITLE
Socket Type Flags: SOCK_NONBLOCK and SOCK_CLOEXEC

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/sys/socket/socket.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/socket/socket.c
@@ -5,11 +5,15 @@
 #include <wasi/api.h>
 #include <errno.h>
 #include <string.h>
+#include <unistd.h>
 
 int socket(int domain, int ty, int protocol) {
   int fd;
+  int flags = ty & (SOCK_NONBLOCK | SOCK_CLOEXEC);
+  int socktype = ty & ~(SOCK_NONBLOCK | SOCK_CLOEXEC);
+
   if(!protocol) {
-    switch (ty)
+    switch (socktype)
     {
     case SOCK_STREAM:
       protocol = IPPROTO_TCP;
@@ -19,10 +23,33 @@ int socket(int domain, int ty, int protocol) {
       break;
     }
   }
-  __wasi_errno_t error = __wasi_sock_open(domain, ty, protocol, &fd);
+  __wasi_errno_t error = __wasi_sock_open(domain, socktype, protocol, &fd);
   if (error != 0) {
     errno = error;
     return -1;
+  }
+
+  if (flags & SOCK_NONBLOCK) {
+    __wasi_fdstat_t fds;
+    error = __wasi_fd_fdstat_get(fd, &fds);
+    if (error == 0) {
+      error = __wasi_fd_fdstat_set_flags(
+          fd, fds.fs_flags | __WASI_FDFLAGS_NONBLOCK);
+    }
+    if (error != 0) {
+      close(fd);
+      errno = error;
+      return -1;
+    }
+  }
+
+  if (flags & SOCK_CLOEXEC) {
+    error = __wasi_fd_fdflags_set(fd, __WASI_FDFLAGSEXT_CLOEXEC);
+    if (error != 0) {
+      close(fd);
+      errno = error;
+      return -1;
+    }
   }
 
   return fd;


### PR DESCRIPTION
In the baseline libc socket wrapper, the type argument can be forwarded to WASIX without separating the base socket type from POSIX creation flags. That is wrong because SOCK_DGRAM | SOCK_NONBLOCK | SOCK_CLOEXEC is not itself a base socket type. The runtime wants to know SOCK_DGRAM; libc must apply SOCK_NONBLOCK and SOCK_CLOEXEC as fd flags.

If libc forwards the combined bits as the socket type, Wasmer may not recognize the socket as datagram or stream. If libc opens the right socket but ignores the flags, the fd remains blocking and code that expects EAGAIN can hang.

Proposed solution: Mask the base socket type before calling WASIX, then apply flags through the normal fd flag paths.

[Detailed description](https://github.com/wasmerio/edgejs/blob/test-wasix-quickjs-only/plans/wasix-plan/wasix-libc/01_socket_type_flags_sock_nonblock_and_sock_cloexec.md#socket-type-flags-sock_nonblock-and-sock_cloexec)