### PR TITLE
fix: don't fail exceptfds with ENOSYS, just zero them'

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/sys/select/pselect.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/select/pselect.c
@@ -18,12 +18,13 @@ int pselect(int nfds, fd_set *restrict readfds, fd_set *restrict writefds,
     return -1;
   }
 
-  // This implementation does not support polling for exceptional
-  // conditions, such as out-of-band data on TCP sockets.
-  if (errorfds != NULL && errorfds->__nfds > 0) {
-    errno = ENOSYS;
-    return -1;
-  }
+  // wasix poll_oneoff has no exceptional-condition (POLLPRI) event type, so we
+  // cannot report out-of-band data. Rather than fail the whole call with ENOSYS
+  // (which breaks defensive callers like rsync that always pass an exceptfds
+  // set and only treat EBADF as fatal, so ENOSYS spins their select loop),
+  // ignore exceptfds and report that no descriptor is exceptional.
+  if (errorfds != NULL)
+    FD_ZERO(errorfds);
 
   // Replace NULL pointers by the empty set.
   fd_set empty;


### PR DESCRIPTION
`pselect` returned `ENOSYS` whenever `errorfds` held any descriptors, since wasix `poll_oneoff` has no exceptional-condition (`POLLPRI`) event type.
This breaks the common idiom of passing all three fd sets defensively and treating only `EBADF` as fatal (e.g. rsync, whose select loop spins on the `ENOSYS`).

Exceptional conditions are unobservable on wasix anyway, so report that no descriptor is exceptional (`FD_ZERO(errorfds)`) and proceed on read/write instead of failing the call. Also fixes `select()`, which forwards to `pselect()`.


