### PR TITLE
fix: make bash shebangs more portable

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#/bin/bash -e
+#/usr/bin/env bash -e
 make clean
 ./build64.sh
 ./build32.sh

--- a/build32-eh.sh
+++ b/build32-eh.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -Eeuxo pipefail
 
 PIC=OFF EH=ON EXNREF_EH=OFF bash build32-general.sh

--- a/build32-ehpic.sh
+++ b/build32-ehpic.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -Eeuxo pipefail
 
 PIC=ON EH=ON EXNREF_EH=OFF bash build32-general.sh

--- a/build32-exnref-eh.sh
+++ b/build32-exnref-eh.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -Eeuxo pipefail
 
 PIC=OFF EH=ON EXNREF_EH=ON bash build32-general.sh

--- a/build32-exnref-ehpic.sh
+++ b/build32-exnref-ehpic.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -Eeuxo pipefail
 
 PIC=ON EH=ON EXNREF_EH=ON bash build32-general.sh

--- a/build32-general.sh
+++ b/build32-general.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -Eeuxo pipefail
 
 ### Determine build configuration

--- a/build32.sh
+++ b/build32.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -Eeuxo pipefail
 
 PIC=OFF EH=OFF bash build32-general.sh

--- a/build64.sh
+++ b/build64.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -Eeuxo pipefail
 

--- a/check-eh-type.sh
+++ b/check-eh-type.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # check-eh-type.sh - Detect whether a WebAssembly sysroot uses legacy or new exception handling
 #

--- a/clean.sh
+++ b/clean.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 make clean
 rm -rf ./build/*

--- a/take-expected.sh
+++ b/take-expected.sh
@@ -1,4 +1,4 @@
-#/bin/bash -e
+#!/usr/bin/env bash -e
 cp -f sysroot/share/wasm32-wasi/defined-symbols.txt expected/wasm32-wasi/defined-symbols.txt
 cp -f sysroot/share/wasm32-wasi/include-all.c expected/wasm32-wasi/include-all.c
 cp -f sysroot/share/wasm32-wasi/predefined-macros.txt expected/wasm32-wasi/predefined-macros.txt

--- a/test/wasix/c_pthreads/test.sh
+++ b/test/wasix/c_pthreads/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tmpfile=$(mktemp)
 wasmer run --verbose --enable-all ./main > $tmpfile

--- a/test/wasix/cpp_atomic/test.sh
+++ b/test/wasix/cpp_atomic/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 wasmer run --verbose --enable-all ./main
 RESULT=$?

--- a/test/wasix/cpp_executable/test.sh
+++ b/test/wasix/cpp_executable/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 wasmer run --verbose --enable-all ./main
 RESULT=$?

--- a/test/wasix/cpp_iostream/test.sh
+++ b/test/wasix/cpp_iostream/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 wasmer run --verbose --enable-all ./main
 RESULT=$?

--- a/test/wasix/cpp_threads/test.sh
+++ b/test/wasix/cpp_threads/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 tmpfile=$(mktemp)
 wasmer run --verbose --enable-all ./main > $tmpfile

--- a/test/wasix/run_tests.sh
+++ b/test/wasix/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 BUILD_DIR=$SCRIPT_DIR/../../test-builds
 TESTS=


### PR DESCRIPTION
`/bin/bash` doesn't exist on NixOS (and BSDs), replace all references with the more portable `/usr/bin/env bash`.

Also drops some leading spaces from some shebangs (I assume those were unintentional)