### PR TITLE
fix(inet): re-add inet_addr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
 	    network/inet_ntoa.c \
         network/inet_pton.c \
         network/inet_aton.c \
+        network/inet_addr.c \
         network/in6addr_any.c \
         network/in6addr_loopback.c \
         network/proto.c \

--- a/Makefile-eh
+++ b/Makefile-eh
@@ -148,6 +148,7 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
 	    network/inet_ntoa.c \
         network/inet_pton.c \
         network/inet_aton.c \
+        network/inet_addr.c \
         network/in6addr_any.c \
         network/in6addr_loopback.c \
         network/proto.c \

--- a/expected/wasm32-wasi-eh/defined-symbols.txt
+++ b/expected/wasm32-wasi-eh/defined-symbols.txt
@@ -1065,6 +1065,7 @@ imaxdiv
 in6addr_any
 in6addr_loopback
 index
+inet_addr
 inet_aton
 inet_ntoa
 inet_ntop

--- a/expected/wasm32-wasi-ehpic/defined-symbols.txt
+++ b/expected/wasm32-wasi-ehpic/defined-symbols.txt
@@ -1073,6 +1073,7 @@ imaxdiv
 in6addr_any
 in6addr_loopback
 index
+inet_addr
 inet_aton
 inet_ntoa
 inet_ntop

--- a/expected/wasm32-wasi-threads/defined-symbols.txt
+++ b/expected/wasm32-wasi-threads/defined-symbols.txt
@@ -994,6 +994,7 @@ imaxdiv
 in6addr_any
 in6addr_loopback
 index
+inet_addr
 inet_aton
 inet_ntop
 inet_pton

--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -1070,6 +1070,7 @@ imaxdiv
 in6addr_any
 in6addr_loopback
 index
+inet_addr
 inet_aton
 inet_ntoa
 inet_ntop

--- a/expected/wasm64-wasi/defined-symbols.txt
+++ b/expected/wasm64-wasi/defined-symbols.txt
@@ -1026,6 +1026,7 @@ imaxdiv
 in6addr_any
 in6addr_loopback
 index
+inet_addr
 inet_aton
 inet_ntoa
 inet_ntop

--- a/libc-top-half/musl/include/arpa/inet.h
+++ b/libc-top-half/musl/include/arpa/inet.h
@@ -13,8 +13,8 @@ uint16_t htons(uint16_t);
 uint32_t ntohl(uint32_t);
 uint16_t ntohs(uint16_t);
 
-#ifdef __wasilibc_unmodified_upstream /* WASI has no inet_addr */
 in_addr_t inet_addr (const char *);
+#ifdef __wasilibc_unmodified_upstream /* WASI has no inet_network */
 in_addr_t inet_network (const char *);
 #endif
 char *inet_ntoa (struct in_addr);


### PR DESCRIPTION
Adds `inet_addr`, which is currently disabled. It's a pure conversion function so it needs no syscalls or anything and works OOTB from musl.